### PR TITLE
Add COUNT versions of group-empty aggregate tests

### DIFF
--- a/testcases-sparql-1.2/aggregates/agg-empty-group-count-01.rq
+++ b/testcases-sparql-1.2/aggregates/agg-empty-group-count-01.rq
@@ -1,0 +1,6 @@
+PREFIX : <http://example/>
+
+SELECT (count(*) AS ?C)
+WHERE {
+   ?s :p ?x
+}

--- a/testcases-sparql-1.2/aggregates/agg-empty-group-count-01.srj
+++ b/testcases-sparql-1.2/aggregates/agg-empty-group-count-01.srj
@@ -1,0 +1,12 @@
+{
+  "head": {
+    "vars": [ "C" ]
+  } ,
+  "results": {
+    "bindings": [
+      {
+        "C": { "type": "literal" , "datatype": "http://www.w3.org/2001/XMLSchema#integer" , "value": "0" }
+      }
+    ]
+  }
+}

--- a/testcases-sparql-1.2/aggregates/agg-empty-group-count-02.rq
+++ b/testcases-sparql-1.2/aggregates/agg-empty-group-count-02.rq
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+
+SELECT (count(*) AS ?C)
+WHERE {
+   ?s :p ?x
+}
+GROUP BY ?s

--- a/testcases-sparql-1.2/aggregates/agg-empty-group-count-02.srj
+++ b/testcases-sparql-1.2/aggregates/agg-empty-group-count-02.srj
@@ -1,0 +1,10 @@
+{
+  "head": {
+    "vars": [ "C" ]
+  } ,
+  "results": {
+    "bindings": [
+      
+    ]
+  }
+}

--- a/testcases-sparql-1.2/aggregates/manifest.ttl
+++ b/testcases-sparql-1.2/aggregates/manifest.ttl
@@ -12,6 +12,8 @@
     ( 
     :agg-empty-group-1
     :agg-empty-group-2
+    :agg-empty-group-count-01
+    :agg-empty-group-count-02
 ) .
 
 
@@ -32,3 +34,20 @@
            qt:data   <empty.ttl> ] ;
     mf:result  <agg-empty-group-2.srx>
     .    
+
+:agg-empty-group-count-01  rdf:type mf:QueryEvaluationTest ;
+    mf:name "COUNT: no match, no group";
+    mf:action
+         [ qt:query  <agg-empty-group-count-01.rq> ;
+           qt:data   <empty.ttl> ] ;
+    mf:result  <agg-empty-group-count-01.srj>
+    .
+
+:agg-empty-group-count-02  rdf:type mf:QueryEvaluationTest ;
+    mf:name "COUNT: no match, with group";
+    mf:action
+         [ qt:query  <agg-empty-group-count-02.rq> ;
+           qt:data   <empty.ttl> ] ;
+    mf:result  <agg-empty-group-count-02.srj>
+    .
+


### PR DESCRIPTION
This adds two tests that use COUNT because the COUNT(*) aggregate always returns a value.